### PR TITLE
map_crs: add `allow_override` and `transform` options

### DIFF
--- a/docs/api-hidden.rst
+++ b/docs/api-hidden.rst
@@ -14,3 +14,4 @@
    ProjAccessorMixin._proj_set_crs
    ProjIndexMixin._proj_get_crs
    ProjIndexMixin._proj_set_crs
+   ProjIndexMixin._proj_to_crs

--- a/docs/integration.md
+++ b/docs/integration.md
@@ -18,10 +18,10 @@ kernelspec:
 - simply consume the API exposed via the {ref}`"proj" Dataset and DataArray
   accessors <proj_accessors>`.
 
-- register a custom Xarray accessor that implements XProj's {term}`accessor
+- register a custom Xarray accessor that implements the {term}`proj accessor
   interface` (example below)
 
-- implement one or more methods of XProj's {term}`index interface` in a custom
+- implement one or more methods of the {term}`proj index interface` in a custom
   Xarray index (example below)
 
 <br>
@@ -41,7 +41,7 @@ that is also explictly registered with the {func}`xproj.register_accessor`
 decorator. It inherits from {class}`~xproj.ProjAccessorMixin`.
 
 Registering this "geo" accessor allows executing custom logic from within the
-accessor (via XProj's {term}`accessor interface`) when calling `xproj` API.
+accessor (via the {term}`proj accessor interface`) when calling `xproj` API.
 
 :::{note}
 The {func}`xproj.register_accessor` decorator must be applied after (on top of)
@@ -122,8 +122,8 @@ class GeoIndex(xr.indexes.PandasIndex, xproj.ProjIndexMixin):
     def _proj_get_crs(self):
         return self._crs
 
-    def _proj_set_crs(self, crs_coord_name, crs):
-        # `crs_coord_name` is not used here
+    def _proj_set_crs(self, spatial_ref, crs):
+        # note: `spatial_ref` is not used here
         print(f"set CRS of index {self!r} to crs={crs}!")
 
         self._crs = crs
@@ -170,7 +170,7 @@ ds_geo_wgs84 = ds_geo_wgs84.proj.map_crs(spatial_ref=["lat", "lon"])
 ```
 
 The CRS of the "lat" and "lon" geo-indexed coordinates is updated via the
-{term}`index interface` implemented in ``GeoIndex``. Data selection is now
+{term}`proj index interface` implemented in ``GeoIndex``. Data selection is now
 CRS-aware! (just a warning is emitted below).
 
 ```{code-cell} ipython3
@@ -199,7 +199,7 @@ temp
 ```
 
 ```{code-cell} ipython3
-ds_geo_wgs72 = temp.proj.map_crs(spatial_ref=["lat", "lon"])
+ds_geo_wgs72 = temp.proj.map_crs(spatial_ref=["lat", "lon"], allow_override=True)
 
 # up-to-date CRS
 ds_geo_wgs72

--- a/docs/terminology.md
+++ b/docs/terminology.md
@@ -27,9 +27,9 @@ CRS-aware index
    features, etc.). It is distinct from a {class}`~xproj.CRSIndex`, which is
    exclusively associated with a {term}`spatial reference coordinate`. XProj
    identifies an Xarray index as CRS-aware if the latter implements the
-   {term}`index interface`.
+   {term}`proj index interface`.
 
-Index interface
+Proj index interface
    A set of XProj-specific "hook" methods that can be implemented in a
    {term}`CRS-aware index` and that allow executing custom logic (e.g.,
    coordinate transformation) or updating the internal state of the index via
@@ -38,11 +38,11 @@ Index interface
    {class}`~xproj.ProjIndexMixin`, although it is not required for an Xarray
    Index to inherit from this mixin class.
 
-Accessor interface
+Proj accessor interface
    A set of XProj-specific "hook" methods that can be implemented in an Xarray
    Dataset or DataArray accessor and that allow executing custom logic (e.g.,
    re-projection) or updating the internal state of the accessor via XProj's
-   public API. The accessor interface is defined in
+   public API. The proj accessor interface is defined in
    {class}`~xproj.ProjAccessorMixin`, from which the accessor class should
    inherit.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,6 @@ Documentation = "https://xproj.readthedocs.io"
 Repository = "https://github.com/benbovy/xproj"
 
 [tool.ruff]
-target-version = "py311"
 builtins = ["ellipsis"]
 exclude = [
   ".git",

--- a/xproj/mixins.py
+++ b/xproj/mixins.py
@@ -1,9 +1,21 @@
 import abc
+import sys
 from collections.abc import Hashable
-from typing import Generic, Self, TypeVar
+from typing import TYPE_CHECKING, Any, Generic, Self, TypeVar
 
 import pyproj
 import xarray as xr
+
+try:
+    if sys.version_info >= (3, 11):
+        from typing import Self
+    else:
+        from typing_extensions import Self
+except ImportError:
+    if TYPE_CHECKING:
+        raise
+    else:
+        Self: Any = None
 
 T_Xarray_Object = TypeVar("T_Xarray_Object", xr.Dataset, xr.DataArray)
 

--- a/xproj/mixins.py
+++ b/xproj/mixins.py
@@ -1,6 +1,6 @@
 import abc
 from collections.abc import Hashable
-from typing import Generic, TypeVar
+from typing import Generic, Self, TypeVar
 
 import pyproj
 import xarray as xr
@@ -49,10 +49,10 @@ class ProjIndexMixin(abc.ABC):
         ...
 
     def _proj_set_crs(
-        self,
+        self: Self,
         spatial_ref: Hashable,
         crs: pyproj.CRS,
-    ) -> T_Xarray_Object:
+    ) -> Self:
         """Method called when mapping a CRS to index coordinate(s) via
         :py:meth:`xarray.Dataset.proj.map_crs`.
 
@@ -65,17 +65,17 @@ class ProjIndexMixin(abc.ABC):
 
         Returns
         -------
-        xarray.Dataset or xarray.DataArray
-            Either a new or an existing Dataset or DataArray.
+        Index
+            Either a new or an existing xarray Index.
 
         """
         raise NotImplementedError("This CRS-aware index does not support (re)setting the CRS.")
 
     def _proj_to_crs(
-        self,
+        self: Self,
         spatial_ref: Hashable,
         crs: pyproj.CRS,
-    ) -> T_Xarray_Object:
+    ) -> Self:
         """Method called when mapping a CRS to index coordinate(s) via
         :py:meth:`xarray.Dataset.proj.map_crs` with ``transform=True``.
 
@@ -88,8 +88,8 @@ class ProjIndexMixin(abc.ABC):
 
         Returns
         -------
-        xarray.Dataset or xarray.DataArray
-            Either a new or an existing Dataset or DataArray.
+        Index
+            Either a new or an existing xarray Index.
 
         """
         raise NotImplementedError(

--- a/xproj/mixins.py
+++ b/xproj/mixins.py
@@ -1,7 +1,7 @@
 import abc
 import sys
 from collections.abc import Hashable
-from typing import TYPE_CHECKING, Any, Generic, Self, TypeVar
+from typing import TYPE_CHECKING, Any, Generic, TypeVar
 
 import pyproj
 import xarray as xr

--- a/xproj/mixins.py
+++ b/xproj/mixins.py
@@ -37,20 +37,24 @@ class ProjIndexMixin(abc.ABC):
     """Mixin class that marks XProj support for an Xarray index."""
 
     @abc.abstractmethod
-    def _proj_get_crs(self) -> pyproj.CRS:
+    def _proj_get_crs(self) -> pyproj.CRS | None:
         """XProj access to the CRS of the index.
 
         Returns
         -------
-        pyproj.crs.CRS
-            The CRS of the index.
+        pyproj.crs.CRS or None
+            The CRS of the index or None if not (yet) defined.
 
         """
         ...
 
-    def _proj_set_crs(self, spatial_ref: Hashable, crs: pyproj.CRS) -> T_Xarray_Object | None:
+    def _proj_set_crs(
+        self,
+        spatial_ref: Hashable,
+        crs: pyproj.CRS,
+    ) -> T_Xarray_Object:
         """Method called when mapping a CRS to index coordinate(s) via
-        :py:meth:`xarray.Dataset.proj.map_crs()`.
+        :py:meth:`xarray.Dataset.proj.map_crs`.
 
         Parameters
         ----------
@@ -61,9 +65,34 @@ class ProjIndexMixin(abc.ABC):
 
         Returns
         -------
-        xarray.Dataset or xarray.DataArray or None
-            Either a new or an existing Dataset or DataArray,
-            or None (default).
+        xarray.Dataset or xarray.DataArray
+            Either a new or an existing Dataset or DataArray.
 
         """
-        return None
+        raise NotImplementedError("This CRS-aware index does not support (re)setting the CRS.")
+
+    def _proj_to_crs(
+        self,
+        spatial_ref: Hashable,
+        crs: pyproj.CRS,
+    ) -> T_Xarray_Object:
+        """Method called when mapping a CRS to index coordinate(s) via
+        :py:meth:`xarray.Dataset.proj.map_crs` with ``transform=True``.
+
+        Parameters
+        ----------
+        spatial_ref : Hashable
+            The name of the spatial reference (scalar) coordinate.
+        crs : pyproj.crs.CRS
+            The new CRS attached to the spatial reference coordinate.
+
+        Returns
+        -------
+        xarray.Dataset or xarray.DataArray
+            Either a new or an existing Dataset or DataArray.
+
+        """
+        raise NotImplementedError(
+            "This CRS-aware index does not support (re)setting the CRS "
+            "with coordinate data transformation."
+        )

--- a/xproj/tests/test_3rdparty_index.py
+++ b/xproj/tests/test_3rdparty_index.py
@@ -6,32 +6,35 @@ from xarray.indexes import PandasIndex
 import xproj
 
 
-class ImmutableCRSIndex(PandasIndex):
-    def _proj_get_crs(self):
-        return pyproj.CRS.from_epsg(4326)
-
-
-class MutableCRSIndex(PandasIndex):
+class CRSAwareIndex(PandasIndex):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._crs = None
+        self.transformed = False
 
     def _proj_get_crs(self):
         return self._crs
 
-    def _proj_set_crs(self, crs_coord_name, crs):
+    def _proj_set_crs(self, spatial_ref, crs):
         self._crs = crs
         return self
 
+    def _proj_to_crs(self, spatial_ref, crs):
+        new_index = self._copy()
+        new_index._crs = crs
+        new_index.transformed = True
+        return new_index
+
     def _copy(self, deep=True, memo=None):
-        # bug in PandasIndex? crs attribute not copied here
+        # bug in PandasIndex? subclass attribute not copied
         obj = super()._copy(deep=deep, memo=memo)
         obj._crs = self._crs
+        obj.transformed = self.transformed
         return obj
 
 
 def test_index_mixin_abstract() -> None:
-    class Index(PandasIndex, xproj.ProjAccessorMixin):
+    class Index(PandasIndex, xproj.ProjIndexMixin):
         def __init__(self, *args, **kwargs):
             super().__init__(*args, **kwargs)
 
@@ -41,15 +44,58 @@ def test_index_mixin_abstract() -> None:
 
 def test_map_crs() -> None:
     ds = (
-        xr.Dataset(coords={"foo": ("x", [1, 2]), "bar": ("y", [3, 4])})
-        .set_xindex("foo", ImmutableCRSIndex)
-        .set_xindex("bar", MutableCRSIndex)
-        .proj.assign_crs(spatial_ref=pyproj.CRS.from_epsg(4978))
+        xr.Dataset(coords={"foo": ("x", [1, 2])})
+        .set_xindex("foo", CRSAwareIndex)
+        .proj.assign_crs(spatial_ref=pyproj.CRS.from_epsg(4326))
     )
 
-    with pytest.warns(UserWarning, match="won't have any effect"):
-        ds_mapped = ds.proj.map_crs(spatial_ref=["foo"])
-    ds_mapped = ds_mapped.proj.map_crs(spatial_ref=["bar"])
-
+    ds_mapped = ds.proj.map_crs(spatial_ref=["foo"])
     assert ds_mapped.proj("foo").crs == pyproj.CRS.from_epsg(4326)
-    assert ds_mapped.proj("bar").crs == pyproj.CRS.from_epsg(4978)
+
+    # override + transform
+    ds2 = ds_mapped.proj.assign_crs(spatial_ref=pyproj.CRS.from_epsg(4978), allow_override=True)
+
+    with pytest.raises(ValueError, match="allow_override=False"):
+        ds2.proj.map_crs(spatial_ref=["foo"])
+
+    ds2_mapped = ds2.proj.map_crs(spatial_ref=["foo"], allow_override=True, transform=True)
+    assert ds2_mapped.proj("foo").crs == pyproj.CRS.from_epsg(4978)
+    assert ds2_mapped.xindexes["foo"].transformed is True
+
+
+def test_map_crs_warns() -> None:
+    # map CRS to a default PandasIndex -> not effect (warning)
+    ds = xr.Dataset(coords={"x": [1, 2]})
+    ds = ds.proj.assign_crs(spatial_ref=pyproj.CRS.from_epsg(4326))
+
+    with pytest.warns(UserWarning, match=r"the index.*not recognized as CRS-aware.*"):
+        ds.proj.map_crs(spatial_ref=["x"])
+
+
+@pytest.mark.parametrize("epsg,crs_match", [(4326, True), (4978, False)])
+def test_map_crs_read_only(epsg, crs_match) -> None:
+    # try mapping the CRS a spatial ref coordinate to a CRS-aware index
+    # that has read-only CRS access
+
+    class ImmutableCRSAwareIndex(PandasIndex, xproj.ProjIndexMixin):
+        def _proj_get_crs(self):
+            return pyproj.CRS.from_epsg(4326)
+
+    ds = (
+        xr.Dataset(coords={"foo": ("x", [1, 2])})
+        .set_xindex("foo", ImmutableCRSAwareIndex)
+        .proj.assign_crs(spatial_ref=pyproj.CRS.from_epsg(epsg))
+    )
+
+    # works if CRS match (map_crs has no effect)
+    if crs_match:
+        ds_mapped = ds.proj.map_crs(spatial_ref=["foo"])
+        assert ds_mapped.proj("foo").crs == ds_mapped.proj("spatial_ref").crs
+
+    # error if CRS mismatch
+    else:
+        with pytest.raises(NotImplementedError):
+            ds.proj.map_crs(spatial_ref=["foo"], allow_override=True)
+
+        with pytest.raises(NotImplementedError):
+            ds.proj.map_crs(spatial_ref=["foo"], allow_override=True, transform=True)

--- a/xproj/tests/test_accessor.py
+++ b/xproj/tests/test_accessor.py
@@ -214,6 +214,7 @@ def test_accessor_map_crs_multicoord_index() -> None:
     class RasterIndex(Index):
         def __init__(self, xy_indexes):
             self._xyindexes = xy_indexes
+            self._crs = None
 
         @classmethod
         def from_variables(cls, variables, *, options):
@@ -226,7 +227,7 @@ def test_accessor_map_crs_multicoord_index() -> None:
         def _proj_get_crs(self):
             return self._crs
 
-        def _proj_set_crs(self, crs_coord_name, crs):
+        def _proj_set_crs(self, spatial_ref, crs):
             self._crs = crs
             return self
 


### PR DESCRIPTION
- `allow_override=False` (default) prevents overriding the CRS of an index if it is defined and different from the mapped CRS.
- `transform=True` allows transforming the coordinate data so it conforms to the mapped CRS. This is possible via the index's `_proj_to_crs()` method newly introduced here.

`map_crs()` may now also raise an error if a CRS-aware index doesn't implement `_proj_set_crs()` or `_proj_to_crs()`.